### PR TITLE
Dashless lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ will get converted to:
   }}
 ```
 
+In partial templates, the prefixing dash will be ignored when generating the translation key, so within `app/templates/post/-form.hbs`
+```hbs
+{{t '.submit'}}
+```
+
+will get converted to:
+```hbs
+{{t 'posts.form.submit'}}
+```
+
 ## Installation
 
 ```shell

--- a/index.js
+++ b/index.js
@@ -40,6 +40,12 @@ I18nLazyLookup.prototype.processString = function (str, relativePath) {
   // Remove app-name and templates/controllers/components prefix
   pathChunks.shift();
   pathChunks.shift();
+
+  // Ignore dash prefix for partial templates
+  if (pathChunks[pathChunks.length - 1].charAt(0) === "-") {
+    pathChunks[pathChunks.length - 1] = pathChunks[pathChunks.length - 1].substring(1);
+  }
+
   prefix = pathChunks.join('.');
 
   if (extension === 'js') {

--- a/tests/fixtures/dummy/app/templates/-partial-dash-prefixed.hbs
+++ b/tests/fixtures/dummy/app/templates/-partial-dash-prefixed.hbs
@@ -1,0 +1,1 @@
+<h1>{{t '.lazy_lookup'}}</h1>

--- a/tests/index.js
+++ b/tests/index.js
@@ -103,4 +103,20 @@ describe('broccoli-i18n-lazy-lookup', function() {
       expect(actual).to.equal(expected);
     });
   })
+
+  it('ignores the initial dash in dash prefixed partial templates', function() {
+    expect(1);
+
+    var sourcePath = 'tests/fixtures/dummy';
+    var tree = replace(sourcePath);
+
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function(dir) {
+      var actual = fs.readFileSync(dir + '/app/templates/-partial-dash-prefixed.hbs',
+        { encoding: 'utf8'});
+      var expected = '<h1>{{t \'partial-dash-prefixed.lazy_lookup\'}}</h1>\n';
+
+      expect(actual).to.equal(expected);
+    });
+  })
 });


### PR DESCRIPTION
Ignores the initial dash in partial template filenames, as per #1. Happy to make additional changes if necessary.
